### PR TITLE
#45 Health Check

### DIFF
--- a/src/In.ProjectEKA.HipService/HealthCheckMiddleware.cs
+++ b/src/In.ProjectEKA.HipService/HealthCheckMiddleware.cs
@@ -1,0 +1,40 @@
+// You may need to install the Microsoft.AspNetCore.Http.Abstractions package into your project
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.OpenMrs;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+public class HealthCheckMiddleware {
+    private readonly RequestDelegate _next;
+
+    public HealthCheckMiddleware (RequestDelegate next) {
+        _next = next;
+    }
+
+    public async Task Invoke (HttpContext httpContext, IHealthCheckClient healthCheckClient) {
+        Dictionary<string, string> healthResult = await healthCheckClient.CheckHealth ();
+        bool healthy = true;
+        foreach (var entry in healthResult) {
+            if (entry.Value != "Healthy") {
+                healthy = false;
+                break;
+            }
+        }
+        if (!healthy) {
+            httpContext.Response.StatusCode = 500;
+            await httpContext.Response.WriteAsync (JsonConvert.SerializeObject (healthResult));
+        } else {
+            await _next (httpContext);
+        }
+    }
+}
+
+public static class HealthCheckMiddlewareExtensions {
+    public static IApplicationBuilder UseHealthCheckMiddleware (this IApplicationBuilder builder) {
+        return builder.UseMiddleware<HealthCheckMiddleware> ();
+    }
+}

--- a/src/In.ProjectEKA.HipService/OpenMrs/IHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/IHealthCheckClient.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+namespace In.ProjectEKA.HipService.OpenMrs {
+    public interface IHealthCheckClient {
+        Task<Dictionary<string, string>> CheckHealth ();
+    }
+}

--- a/src/In.ProjectEKA.HipService/OpenMrs/OpenMrsHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/OpenMrsHealthCheckClient.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.Logger;
+
+namespace In.ProjectEKA.HipService.OpenMrs {
+    public class OpenMrsHealthCheckClient : IHealthCheckClient {
+        Dictionary<string, string> endpoints;
+        IOpenMrsClient openMrsClient;
+
+        public OpenMrsHealthCheckClient (Dictionary<string, string> initEndpoints, IOpenMrsClient client) {
+            endpoints = initEndpoints;
+            openMrsClient = client;
+        }
+
+        public async Task<Dictionary<string, string>> CheckHealth () {
+            Dictionary<string, string> result = new Dictionary<string, string> ();
+            foreach (var entry in endpoints) {
+                try {
+                    var response = await openMrsClient.GetAsync (entry.Value);
+                    if (response.StatusCode == HttpStatusCode.OK) {
+                        result.Add (entry.Key, "Healthy");
+                    } else {
+                        result.Add (entry.Key, "Unhealthy");
+                    }
+                } catch (Exception e) {
+                    result.Add (entry.Key, "Unhealthy");
+                    Console.WriteLine (e);
+                }
+            }
+            return result;
+        }
+
+    }
+}

--- a/test/In.ProjectEKA.HipServiceTest/HealthCheck/HealthCheckClientTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/HealthCheck/HealthCheckClientTest.cs
@@ -1,0 +1,29 @@
+namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+    using FluentAssertions;
+    using In.ProjectEKA.HipService.OpenMrs;
+    using Moq;
+    using Xunit;
+
+    [Collection ("Health Check Client Tests")]
+    public class HealthCareClientTest {
+        private Mock<IHealthCheckClient> healthCheckClient;
+
+        [Fact]
+        private async void ShouldReturnDictionaryWhenCheckingForHealth () {
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (new Dictionary<string, string> ()));
+
+            var result = await healthCheckClient.Object.CheckHealth ();
+
+            Assert.True (result.GetType ().Equals (new Dictionary<string, string> ().GetType ()));
+        }
+
+    }
+}

--- a/test/In.ProjectEKA.HipServiceTest/HealthCheck/HealthCheckClientTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/HealthCheck/HealthCheckClientTest.cs
@@ -7,11 +7,12 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs {
     using System;
     using FluentAssertions;
     using In.ProjectEKA.HipService.OpenMrs;
+    using Moq.Protected;
     using Moq;
     using Xunit;
 
     [Collection ("Health Check Client Tests")]
-    public class HealthCareClientTest {
+    public class HealthCheckClientTest {
         private Mock<IHealthCheckClient> healthCheckClient;
 
         [Fact]
@@ -25,5 +26,89 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs {
             Assert.True (result.GetType ().Equals (new Dictionary<string, string> ().GetType ()));
         }
 
+        [Fact]
+        private async void ShouldReturnServiceAsHealthyWhenServiceHasStatus200 () {
+            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
+            var httpClient = new HttpClient (handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration {
+                Url = "https://someurl/openmrs/",
+                Username = "someusername",
+                Password = "somepassword"
+            };
+            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            handlerMock
+                .Protected ()
+                .Setup<Task<HttpResponseMessage>> (
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage> (),
+                    ItExpr.IsAny<CancellationToken> ()
+                )
+                .ReturnsAsync (new HttpResponseMessage {
+                    StatusCode = HttpStatusCode.OK
+                })
+                .Verifiable ();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+            }, openmrsClient);
+
+            var result = await openMrsHealthCheckClient.CheckHealth ();
+
+            Assert.True (result["Service"].Equals ("Healthy"));
+        }
+
+        [Fact]
+        private async void ShouldReturnServiceAsUnhealthyWhenServiceHasStatus400 () {
+            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
+            var httpClient = new HttpClient (handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration {
+                Url = "https://someurl/openmrs/",
+                Username = "someusername",
+                Password = "somepassword"
+            };
+            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            handlerMock
+                .Protected ()
+                .Setup<Task<HttpResponseMessage>> (
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage> (),
+                    ItExpr.IsAny<CancellationToken> ()
+                )
+                .ReturnsAsync (new HttpResponseMessage {
+                    StatusCode = HttpStatusCode.BadRequest
+                })
+                .Verifiable ();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+            }, openmrsClient);
+
+            var result = await openMrsHealthCheckClient.CheckHealth ();
+
+            Assert.True (result["Service"].Equals ("Unhealthy"));
+        }
+
+        [Fact]
+        private async void ShouldReturnServiceAsUnhealthyWhenRequestThrowsException () {
+            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
+            var httpClient = new HttpClient (handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration {
+                Url = "https://someurl/openmrs/",
+                Username = "someusername",
+                Password = "somepassword"
+            };
+            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            handlerMock
+                .Protected ()
+                .Setup<Task<HttpResponseMessage>> (
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage> (),
+                    ItExpr.IsAny<CancellationToken> ()
+                )
+                .ThrowsAsync (new Exception ("Throw some exception"))
+                .Verifiable ();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+            }, openmrsClient);
+
+            var result = await openMrsHealthCheckClient.CheckHealth ();
+
+            Assert.True (result["Service"].Equals ("Unhealthy"));
+        }
     }
 }

--- a/test/In.ProjectEKA.HipServiceTest/HealthCheck/HealthCheckMiddlewareTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/HealthCheck/HealthCheckMiddlewareTest.cs
@@ -1,0 +1,75 @@
+namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net.Http;
+    using System.Net;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+    using FluentAssertions;
+    using In.ProjectEKA.HipService.OpenMrs;
+    using In.ProjectEKA.HipService;
+    using Microsoft.AspNetCore.Http;
+    using Moq.Protected;
+    using Moq;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    [Collection ("Health Check Middleware Tests")]
+    public class HealthCheckMiddlewareTest {
+
+        private Mock<IHealthCheckClient> healthCheckClient;
+        private HealthCheckMiddleware healthCheckMiddleWare;
+
+        public HealthCheckMiddlewareTest () {
+            healthCheckMiddleWare = new HealthCheckMiddleware (async (innerHttpContext) => {
+                innerHttpContext.Response.StatusCode = 200;
+                await innerHttpContext.Response.WriteAsync ("Success");
+            });
+        }
+
+        [Fact]
+        private async void ShouldReturnStatus500WithDetailsEvenIfOneServiceIsUnhealthy () {
+            var sampleServiceData = new Dictionary<string, string> () { { "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (sampleServiceData));
+            var context = new DefaultHttpContext ();
+            context.Response.Body = new MemoryStream ();
+            var expectedResult = JsonConvert.SerializeObject (sampleServiceData);
+
+            await healthCheckMiddleWare.Invoke (context, healthCheckClient.Object);
+            context.Response.Body.Seek (0, SeekOrigin.Begin);
+            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+
+            responseBody
+                .Should ()
+                .BeEquivalentTo (expectedResult);
+            context.Response.StatusCode
+                .Should ()
+                .Be (500);
+        }
+
+        [Fact]
+        private async void ShouldReturnStatus200WithDetailsIfAllTheServicesAreHealthy () {
+            var sampleServiceData = new Dictionary<string, string> () { { "Service1", "Healthy" }, { "Service2", "Healthy" } };
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (sampleServiceData));
+            var context = new DefaultHttpContext ();
+            context.Response.Body = new MemoryStream ();
+            var expectedResult = "Success";
+
+            await healthCheckMiddleWare.Invoke (context, healthCheckClient.Object);
+            context.Response.Body.Seek (0, SeekOrigin.Begin);
+            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+
+            responseBody
+                .Should ()
+                .BeEquivalentTo (expectedResult);
+            context.Response.StatusCode
+                .Should ()
+                .Be (200);
+        }
+    }
+}


### PR DESCRIPTION
The development addresses the following cases
1) When all the services are healthy -
    a) Ping "/health" endpoint - would give a 200 status with "Healthy" as Response
    b) All other endpoints would work the same way they did before without any errors
2) When even one service is unhealthy - 
    a) Ping "/health" endpoint - would give a 500 status with the response: the services and their health status in JSON. If a service is unhealthy the message would be "Unhealthy" else "Healthy"
    b) All other endpoints -  same response as above 