### PR TITLE
HIP45 - Health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - db
       - rabbitmq
       - otp
+    environment: 
+      - HEALTH_CHECK_DURATION=5000
   otp:
     build: src/In.ProjectEKA.OtpService/.
     depends_on:

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckMiddleware.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckMiddleware.cs
@@ -1,0 +1,49 @@
+// You may need to install the Microsoft.AspNetCore.Http.Abstractions package into your project
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.OpenMrs;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using In.ProjectEKA.HipService;
+using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+
+public class HealthCheckMiddleware {
+    private readonly RequestDelegate _next;
+    private readonly IHealthCheckStatus healthCheckStatus;
+    private readonly HealthChecker healthChecker;
+
+    public HealthCheckMiddleware (RequestDelegate next,IHealthCheckStatus inithealthCheckStatus,IServiceProvider serviceProvider) {
+        healthChecker = (HealthChecker)serviceProvider.GetService(typeof(HealthChecker));
+        healthCheckStatus = inithealthCheckStatus;
+        _next = next;
+    }
+
+    public async Task Invoke (HttpContext httpContext) {
+        Dictionary<string, string> healthStatus =  healthCheckStatus.GetStatus("health");
+        bool healthy = true;
+        if(healthStatus!=null){
+            foreach (var entry in healthStatus) {
+                if (entry.Value != "Healthy") {
+                    healthy = false;
+                    break;
+                }
+            }
+        }
+        if (!healthy) {
+            httpContext.Response.StatusCode = 500;
+            await httpContext.Response.WriteAsync (JsonConvert.SerializeObject (healthStatus));
+        } else {
+            await _next (httpContext);
+        }
+    }
+}
+
+public static class HealthCheckMiddlewareExtensions {
+    public static IApplicationBuilder UseHealthCheckMiddleware (this IApplicationBuilder builder) {
+        return builder.UseMiddleware<HealthCheckMiddleware> ();
+    }
+}

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckMiddleware.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckMiddleware.cs
@@ -1,14 +1,10 @@
 // You may need to install the Microsoft.AspNetCore.Http.Abstractions package into your project
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using In.ProjectEKA.HipService.OpenMrs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Newtonsoft.Json;
-using In.ProjectEKA.HipService;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
 public class HealthCheckMiddleware

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckMiddleware.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckMiddleware.cs
@@ -11,39 +11,50 @@ using Newtonsoft.Json;
 using In.ProjectEKA.HipService;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
-public class HealthCheckMiddleware {
+public class HealthCheckMiddleware
+{
     private readonly RequestDelegate _next;
     private readonly IHealthCheckStatus healthCheckStatus;
     private readonly HealthChecker healthChecker;
 
-    public HealthCheckMiddleware (RequestDelegate next,IHealthCheckStatus inithealthCheckStatus,IServiceProvider serviceProvider) {
+    public HealthCheckMiddleware(RequestDelegate next, IHealthCheckStatus inithealthCheckStatus, IServiceProvider serviceProvider)
+    {
         healthChecker = (HealthChecker)serviceProvider.GetService(typeof(HealthChecker));
         healthCheckStatus = inithealthCheckStatus;
         _next = next;
     }
 
-    public async Task Invoke (HttpContext httpContext) {
-        Dictionary<string, string> healthStatus =  healthCheckStatus.GetStatus("health");
+    public async Task Invoke(HttpContext httpContext)
+    {
+        Dictionary<string, string> healthStatus = healthCheckStatus.GetStatus("health");
         bool healthy = true;
-        if(healthStatus!=null){
-            foreach (var entry in healthStatus) {
-                if (entry.Value != "Healthy") {
+        if (healthStatus != null)
+        {
+            foreach (var entry in healthStatus)
+            {
+                if (entry.Value != "Healthy")
+                {
                     healthy = false;
                     break;
                 }
             }
         }
-        if (!healthy) {
+        if (!healthy)
+        {
             httpContext.Response.StatusCode = 500;
-            await httpContext.Response.WriteAsync (JsonConvert.SerializeObject (healthStatus));
-        } else {
-            await _next (httpContext);
+            await httpContext.Response.WriteAsync(JsonConvert.SerializeObject(healthStatus));
+        }
+        else
+        {
+            await _next(httpContext);
         }
     }
 }
 
-public static class HealthCheckMiddlewareExtensions {
-    public static IApplicationBuilder UseHealthCheckMiddleware (this IApplicationBuilder builder) {
-        return builder.UseMiddleware<HealthCheckMiddleware> ();
+public static class HealthCheckMiddlewareExtensions
+{
+    public static IApplicationBuilder UseHealthCheckMiddleware(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<HealthCheckMiddleware>();
     }
 }

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckStatus.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckStatus.cs
@@ -1,12 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using In.ProjectEKA.HipService.OpenMrs;
-using In.ProjectEKA.HipService;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
 public class HealthCheckStatus : IHealthCheckStatus

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckStatus.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckStatus.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.OpenMrs;
+using In.ProjectEKA.HipService;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+
+public class HealthCheckStatus : IHealthCheckStatus {
+    Dictionary<string,Dictionary<string,string>> statusData = new Dictionary<string,Dictionary<string,string>>();
+    public void AddStatus(string key, Dictionary<string,string> value){
+        if(statusData.ContainsKey(key)){
+            statusData[key]=value;
+            Console.WriteLine("updated the status data "+key);
+        }else {
+            statusData.Add(key,value);
+            Console.WriteLine("added the status data "+key);
+        }
+    }
+    
+    public Dictionary<string,string> GetStatus(string key){
+        if(statusData.ContainsKey(key)){
+            return statusData[key];
+        }
+        return null;
+    }        
+    
+}
+

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckStatus.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthCheckStatus.cs
@@ -9,24 +9,29 @@ using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
-public class HealthCheckStatus : IHealthCheckStatus {
-    Dictionary<string,Dictionary<string,string>> statusData = new Dictionary<string,Dictionary<string,string>>();
-    public void AddStatus(string key, Dictionary<string,string> value){
-        if(statusData.ContainsKey(key)){
-            statusData[key]=value;
-            Console.WriteLine("updated the status data "+key);
-        }else {
-            statusData.Add(key,value);
-            Console.WriteLine("added the status data "+key);
+public class HealthCheckStatus : IHealthCheckStatus
+{
+    Dictionary<string, Dictionary<string, string>> statusData = new Dictionary<string, Dictionary<string, string>>();
+    public void AddStatus(string key, Dictionary<string, string> value)
+    {
+        if (statusData.ContainsKey(key))
+        {
+            statusData[key] = value;
+        }
+        else
+        {
+            statusData.Add(key, value);
         }
     }
-    
-    public Dictionary<string,string> GetStatus(string key){
-        if(statusData.ContainsKey(key)){
+
+    public Dictionary<string, string> GetStatus(string key)
+    {
+        if (statusData.ContainsKey(key))
+        {
             return statusData[key];
         }
         return null;
-    }        
-    
+    }
+
 }
 

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthChecker.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthChecker.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.OpenMrs;
+using In.ProjectEKA.HipService;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using System.Timers;
+using Microsoft.AspNetCore.Hosting;
+using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+
+    public class HealthChecker {
+        private IHealthCheckClient healthCheckClient;
+        private Timer timer;
+
+        private IHealthCheckStatus healthCheckStatus;
+
+        public HealthChecker (IHealthCheckClient initHealthCheckClient, IHealthCheckStatus inithealthCheckStatus) {
+            Console.WriteLine("Health checker is being created");
+            healthCheckClient = initHealthCheckClient;
+            healthCheckStatus = inithealthCheckStatus;
+            timer = new Timer(Convert.ToInt32(Environment.GetEnvironmentVariable("HEALTH_CHECK_DURATION")));
+            timer.Elapsed += async ( sender, e ) => await UpdateHealthStatus();
+            timer.Start();
+        }
+
+        public async Task UpdateHealthStatus () {
+            Dictionary<string, string> result = await healthCheckClient.CheckHealth(); 
+            healthCheckStatus.AddStatus("health",result);
+        }
+
+    }

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthChecker.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthChecker.cs
@@ -1,15 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using In.ProjectEKA.HipService.OpenMrs;
-using In.ProjectEKA.HipService;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Newtonsoft.Json;
 using System.Timers;
-using Microsoft.AspNetCore.Hosting;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
     public class HealthChecker {

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthChecker.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/HealthChecker.cs
@@ -19,7 +19,6 @@ using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
         private IHealthCheckStatus healthCheckStatus;
 
         public HealthChecker (IHealthCheckClient initHealthCheckClient, IHealthCheckStatus inithealthCheckStatus) {
-            Console.WriteLine("Health checker is being created");
             healthCheckClient = initHealthCheckClient;
             healthCheckStatus = inithealthCheckStatus;
             timer = new Timer(Convert.ToInt32(Environment.GetEnvironmentVariable("HEALTH_CHECK_DURATION")));

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckClient.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 namespace In.ProjectEKA.HipService.OpenMrs.HealthCheck
 {
     public interface IHealthCheckClient

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckClient.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+namespace In.ProjectEKA.HipService.OpenMrs.HealthCheck {
+    public interface IHealthCheckClient {
+        Task<Dictionary<string, string>> CheckHealth ();
+    }
+}

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckClient.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
-namespace In.ProjectEKA.HipService.OpenMrs.HealthCheck {
-    public interface IHealthCheckClient {
-        Task<Dictionary<string, string>> CheckHealth ();
+namespace In.ProjectEKA.HipService.OpenMrs.HealthCheck
+{
+    public interface IHealthCheckClient
+    {
+        Task<Dictionary<string, string>> CheckHealth();
     }
 }

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckStatus.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckStatus.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+namespace In.ProjectEKA.HipService.OpenMrs.HealthCheck
+{
+    public interface IHealthCheckStatus
+    {
+        void AddStatus(string key, Dictionary<string,string> value);
+        Dictionary<string,string> GetStatus(string key);
+    }
+}

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckStatus.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/IHealthCheckStatus.cs
@@ -3,7 +3,7 @@ namespace In.ProjectEKA.HipService.OpenMrs.HealthCheck
 {
     public interface IHealthCheckStatus
     {
-        void AddStatus(string key, Dictionary<string,string> value);
-        Dictionary<string,string> GetStatus(string key);
+        void AddStatus(string key, Dictionary<string, string> value);
+        Dictionary<string, string> GetStatus(string key);
     }
 }

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/OpenMrsHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/OpenMrsHealthCheckClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using In.ProjectEKA.HipService.Logger;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
@@ -37,10 +35,10 @@ namespace In.ProjectEKA.HipService.OpenMrs
                         result.Add(entry.Key, "Unhealthy");
                     }
                 }
-                catch (Exception e)
+                catch (Exception exception)
                 {
                     result.Add(entry.Key, "Unhealthy");
-                    Console.WriteLine(e);
+                    Log.Fatal(exception, exception.StackTrace);
                 }
             }
             return result;

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/OpenMrsHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/OpenMrsHealthCheckClient.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using In.ProjectEKA.HipService.Logger;
+using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+
+namespace In.ProjectEKA.HipService.OpenMrs {
+    public class OpenMrsHealthCheckClient : IHealthCheckClient {
+        Dictionary<string, string> endpoints;
+        IOpenMrsClient openMrsClient;
+
+        public OpenMrsHealthCheckClient (Dictionary<string, string> initEndpoints, IOpenMrsClient client) {
+            endpoints = initEndpoints;
+            openMrsClient = client;
+        }
+
+        public async Task<Dictionary<string, string>> CheckHealth () {
+            Dictionary<string, string> result = new Dictionary<string, string> ();
+            foreach (var entry in endpoints) {
+                try {
+                    var response = await openMrsClient.GetAsync (entry.Value);
+                    if (response.StatusCode == HttpStatusCode.OK) {
+                        result.Add (entry.Key, "Healthy");
+                    } else {
+                        result.Add (entry.Key, "Unhealthy");
+                    }
+                } catch (Exception e) {
+                    result.Add (entry.Key, "Unhealthy");
+                    Console.WriteLine (e);
+                }
+            }
+            return result;
+        }
+
+    }
+}

--- a/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/OpenMrsHealthCheckClient.cs
+++ b/src/In.ProjectEKA.HipService/OpenMrs/HealthCheck/OpenMrsHealthCheckClient.cs
@@ -7,29 +7,40 @@ using System.Threading.Tasks;
 using In.ProjectEKA.HipService.Logger;
 using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
-namespace In.ProjectEKA.HipService.OpenMrs {
-    public class OpenMrsHealthCheckClient : IHealthCheckClient {
+namespace In.ProjectEKA.HipService.OpenMrs
+{
+    public class OpenMrsHealthCheckClient : IHealthCheckClient
+    {
         Dictionary<string, string> endpoints;
         IOpenMrsClient openMrsClient;
 
-        public OpenMrsHealthCheckClient (Dictionary<string, string> initEndpoints, IOpenMrsClient client) {
+        public OpenMrsHealthCheckClient(Dictionary<string, string> initEndpoints, IOpenMrsClient client)
+        {
             endpoints = initEndpoints;
             openMrsClient = client;
         }
 
-        public async Task<Dictionary<string, string>> CheckHealth () {
-            Dictionary<string, string> result = new Dictionary<string, string> ();
-            foreach (var entry in endpoints) {
-                try {
-                    var response = await openMrsClient.GetAsync (entry.Value);
-                    if (response.StatusCode == HttpStatusCode.OK) {
-                        result.Add (entry.Key, "Healthy");
-                    } else {
-                        result.Add (entry.Key, "Unhealthy");
+        public async Task<Dictionary<string, string>> CheckHealth()
+        {
+            Dictionary<string, string> result = new Dictionary<string, string>();
+            foreach (var entry in endpoints)
+            {
+                try
+                {
+                    var response = await openMrsClient.GetAsync(entry.Value);
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        result.Add(entry.Key, "Healthy");
                     }
-                } catch (Exception e) {
-                    result.Add (entry.Key, "Unhealthy");
-                    Console.WriteLine (e);
+                    else
+                    {
+                        result.Add(entry.Key, "Unhealthy");
+                    }
+                }
+                catch (Exception e)
+                {
+                    result.Add(entry.Key, "Unhealthy");
+                    Console.WriteLine(e);
                 }
             }
             return result;

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckMiddlewareTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckMiddlewareTest.cs
@@ -1,4 +1,5 @@
-namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+namespace In.ProjectEKA.HipServiceTest.OpenMrs
+{
     using System.Collections.Generic;
     using System.IO;
     using System.Net.Http;
@@ -7,111 +8,117 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs {
     using System.Threading;
     using System;
     using FluentAssertions;
-    using In.ProjectEKA.HipService.OpenMrs;
     using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+    using In.ProjectEKA.HipService.OpenMrs;
     using In.ProjectEKA.HipService;
+    using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Moq.Protected;
     using Moq;
     using Newtonsoft.Json;
     using Xunit;
-    using Microsoft.AspNetCore.Hosting;
 
-    [Collection ("Health Check Middleware Tests")]
-    public class HealthCheckMiddlewareTest {
+    [Collection("Health Check Middleware Tests")]
+    public class HealthCheckMiddlewareTest
+    {
 
         private Mock<IHealthCheckStatus> healthCheckStatus;
         private Mock<IHealthCheckClient> healthCheckClient;
         private HealthCheckMiddleware healthCheckMiddleWare;
         private Mock<IServiceProvider> serviceProvider;
 
-        public HealthCheckMiddlewareTest () {
+        public HealthCheckMiddlewareTest()
+        {
             Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "5000");
-            healthCheckStatus=new Mock<IHealthCheckStatus>();
-            serviceProvider=new Mock<IServiceProvider>();
-            healthCheckMiddleWare = new HealthCheckMiddleware (async (innerHttpContext) => {
+            healthCheckStatus = new Mock<IHealthCheckStatus>();
+            serviceProvider = new Mock<IServiceProvider>();
+            healthCheckMiddleWare = new HealthCheckMiddleware(async (innerHttpContext) =>
+            {
                 innerHttpContext.Response.StatusCode = 200;
-                await innerHttpContext.Response.WriteAsync ("Success");
-            },healthCheckStatus.Object,serviceProvider.Object);
+                await innerHttpContext.Response.WriteAsync("Success");
+            }, healthCheckStatus.Object, serviceProvider.Object);
         }
 
         [Fact]
-        private async void ShouldReturnStatus500WithDetailsEvenIfOneServiceIsUnhealthy () {
+        private async void ShouldReturnStatus500WithDetailsEvenIfOneServiceIsUnhealthy()
+        {
 
-            var sampleServiceData = new Dictionary<string, string> () {{ "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
-            var context = new DefaultHttpContext ();
-            context.Response.Body = new MemoryStream ();
-            healthCheckClient = new Mock<IHealthCheckClient> ();
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (sampleServiceData));
-            var expectedResult = JsonConvert.SerializeObject (sampleServiceData);
-            
-            Dictionary<string,string> unhealthyresponse=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Healthy" }};
+            var sampleServiceData = new Dictionary<string, string>() { { "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+            healthCheckClient = new Mock<IHealthCheckClient>();
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(sampleServiceData));
+            var expectedResult = JsonConvert.SerializeObject(sampleServiceData);
+
+            Dictionary<string, string> unhealthyresponse = new Dictionary<string, string> { { "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
             healthCheckStatus.Setup(x => x.GetStatus("health"))
-                .Returns (unhealthyresponse);
+                .Returns(unhealthyresponse);
 
-            await healthCheckMiddleWare.Invoke (context);
-            context.Response.Body.Seek (0, SeekOrigin.Begin);
-            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+            await healthCheckMiddleWare.Invoke(context);
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var responseBody = new StreamReader(context.Response.Body).ReadToEnd();
 
             responseBody
-                .Should ()
-                .BeEquivalentTo (expectedResult);
+                .Should()
+                .BeEquivalentTo(expectedResult);
             context.Response.StatusCode
-                .Should ()
-                .Be (500);
+                .Should()
+                .Be(500);
         }
 
         [Fact]
-        private async void ShouldReturnStatus500WithDetailsIfMoreThanOneServicesAreUnhealthy () {
+        private async void ShouldReturnStatus500WithDetailsIfMoreThanOneServicesAreUnhealthy()
+        {
 
-            var sampleServiceData = new Dictionary<string, string> () {{ "Service1", "Unhealthy" }, { "Service2", "Unhealthy" } };
-            var context = new DefaultHttpContext ();
-            context.Response.Body = new MemoryStream ();
-            var expectedResult = JsonConvert.SerializeObject (sampleServiceData);
+            var sampleServiceData = new Dictionary<string, string>() { { "Service1", "Unhealthy" }, { "Service2", "Unhealthy" } };
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+            var expectedResult = JsonConvert.SerializeObject(sampleServiceData);
 
-            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient = new Mock<IHealthCheckClient>();
 
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (sampleServiceData));
-            
-            Dictionary<string,string> unhealthyresponse=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Unhealthy" }};
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(sampleServiceData));
+
+            Dictionary<string, string> unhealthyresponse = new Dictionary<string, string> { { "Service1", "Unhealthy" }, { "Service2", "Unhealthy" } };
             healthCheckStatus.Setup(x => x.GetStatus("health"))
-                .Returns (unhealthyresponse);
+                .Returns(unhealthyresponse);
 
-            await healthCheckMiddleWare.Invoke (context);
-            context.Response.Body.Seek (0, SeekOrigin.Begin);
-            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+            await healthCheckMiddleWare.Invoke(context);
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var responseBody = new StreamReader(context.Response.Body).ReadToEnd();
 
             responseBody
-                .Should ()
-                .BeEquivalentTo (expectedResult);
+                .Should()
+                .BeEquivalentTo(expectedResult);
             context.Response.StatusCode
-                .Should ()
-                .Be (500);
+                .Should()
+                .Be(500);
         }
 
         [Fact]
-        private async void ShouldReturnStatus200WithDetailsIfAllTheServicesAreHealthy () {
-            var sampleServiceData = new Dictionary<string, string> () { { "Service1", "Healthy" }, { "Service2", "Healthy" } };
-            healthCheckClient = new Mock<IHealthCheckClient> ();
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (sampleServiceData));
-            
-            var context = new DefaultHttpContext ();
-            context.Response.Body = new MemoryStream ();
+        private async void ShouldReturnStatus200WithDetailsIfAllTheServicesAreHealthy()
+        {
+            var sampleServiceData = new Dictionary<string, string>() { { "Service1", "Healthy" }, { "Service2", "Healthy" } };
+            healthCheckClient = new Mock<IHealthCheckClient>();
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(sampleServiceData));
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
             var expectedResult = "Success";
 
-            await healthCheckMiddleWare.Invoke (context);
-            context.Response.Body.Seek (0, SeekOrigin.Begin);
-            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+            await healthCheckMiddleWare.Invoke(context);
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            var responseBody = new StreamReader(context.Response.Body).ReadToEnd();
 
             responseBody
-                .Should ()
-                .BeEquivalentTo (expectedResult);
+                .Should()
+                .BeEquivalentTo(expectedResult);
             context.Response.StatusCode
-                .Should ()
-                .Be (200);
+                .Should()
+                .Be(200);
         }
     }
 }

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckMiddlewareTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckMiddlewareTest.cs
@@ -1,0 +1,117 @@
+namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net.Http;
+    using System.Net;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+    using FluentAssertions;
+    using In.ProjectEKA.HipService.OpenMrs;
+    using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+    using In.ProjectEKA.HipService;
+    using Microsoft.AspNetCore.Http;
+    using Moq.Protected;
+    using Moq;
+    using Newtonsoft.Json;
+    using Xunit;
+    using Microsoft.AspNetCore.Hosting;
+
+    [Collection ("Health Check Middleware Tests")]
+    public class HealthCheckMiddlewareTest {
+
+        private Mock<IHealthCheckStatus> healthCheckStatus;
+        private Mock<IHealthCheckClient> healthCheckClient;
+        private HealthCheckMiddleware healthCheckMiddleWare;
+        private Mock<IServiceProvider> serviceProvider;
+
+        public HealthCheckMiddlewareTest () {
+            Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "5000");
+            healthCheckStatus=new Mock<IHealthCheckStatus>();
+            serviceProvider=new Mock<IServiceProvider>();
+            healthCheckMiddleWare = new HealthCheckMiddleware (async (innerHttpContext) => {
+                innerHttpContext.Response.StatusCode = 200;
+                await innerHttpContext.Response.WriteAsync ("Success");
+            },healthCheckStatus.Object,serviceProvider.Object);
+        }
+
+        [Fact]
+        private async void ShouldReturnStatus500WithDetailsEvenIfOneServiceIsUnhealthy () {
+
+            var sampleServiceData = new Dictionary<string, string> () {{ "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
+            var context = new DefaultHttpContext ();
+            context.Response.Body = new MemoryStream ();
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (sampleServiceData));
+            var expectedResult = JsonConvert.SerializeObject (sampleServiceData);
+            
+            Dictionary<string,string> unhealthyresponse=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Healthy" }};
+            healthCheckStatus.Setup(x => x.GetStatus("health"))
+                .Returns (unhealthyresponse);
+
+            await healthCheckMiddleWare.Invoke (context);
+            context.Response.Body.Seek (0, SeekOrigin.Begin);
+            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+
+            responseBody
+                .Should ()
+                .BeEquivalentTo (expectedResult);
+            context.Response.StatusCode
+                .Should ()
+                .Be (500);
+        }
+
+        [Fact]
+        private async void ShouldReturnStatus500WithDetailsIfMoreThanOneServicesAreUnhealthy () {
+
+            var sampleServiceData = new Dictionary<string, string> () {{ "Service1", "Unhealthy" }, { "Service2", "Unhealthy" } };
+            var context = new DefaultHttpContext ();
+            context.Response.Body = new MemoryStream ();
+            var expectedResult = JsonConvert.SerializeObject (sampleServiceData);
+
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (sampleServiceData));
+            
+            Dictionary<string,string> unhealthyresponse=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Unhealthy" }};
+            healthCheckStatus.Setup(x => x.GetStatus("health"))
+                .Returns (unhealthyresponse);
+
+            await healthCheckMiddleWare.Invoke (context);
+            context.Response.Body.Seek (0, SeekOrigin.Begin);
+            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+
+            responseBody
+                .Should ()
+                .BeEquivalentTo (expectedResult);
+            context.Response.StatusCode
+                .Should ()
+                .Be (500);
+        }
+
+        [Fact]
+        private async void ShouldReturnStatus200WithDetailsIfAllTheServicesAreHealthy () {
+            var sampleServiceData = new Dictionary<string, string> () { { "Service1", "Healthy" }, { "Service2", "Healthy" } };
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (sampleServiceData));
+            
+            var context = new DefaultHttpContext ();
+            context.Response.Body = new MemoryStream ();
+            var expectedResult = "Success";
+
+            await healthCheckMiddleWare.Invoke (context);
+            context.Response.Body.Seek (0, SeekOrigin.Begin);
+            var responseBody = new StreamReader (context.Response.Body).ReadToEnd ();
+
+            responseBody
+                .Should ()
+                .BeEquivalentTo (expectedResult);
+            context.Response.StatusCode
+                .Should ()
+                .Be (200);
+        }
+    }
+}

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckStatusTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckStatusTest.cs
@@ -1,4 +1,5 @@
-namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+namespace In.ProjectEKA.HipServiceTest.OpenMrs
+{
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Net;
@@ -12,41 +13,46 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs {
     using Moq;
     using Xunit;
     using Microsoft.AspNetCore.Hosting;
+    using FluentAssertions;
 
-    [Collection ("Health Check Status Tests")]
-    public class HealthCheckStatusTest {
-       
+    [Collection("Health Check Status Tests")]
+    public class HealthCheckStatusTest
+    {
+
         [Fact]
-        private void ShouldAddHealthCheckStatusWhenAddStatusIsInvoked() {
-            Dictionary<string,string> status=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Healthy" }};
-            HealthCheckStatus healthCheckStatus=new HealthCheckStatus();
-            healthCheckStatus.AddStatus("health",status);
+        private void ShouldAddHealthCheckStatusWhenAddStatusIsInvoked()
+        {
+            Dictionary<string, string> status = new Dictionary<string, string> { { "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
+            HealthCheckStatus healthCheckStatus = new HealthCheckStatus();
+            healthCheckStatus.AddStatus("health", status);
 
-            Dictionary<string,string> result = healthCheckStatus.GetStatus("health");
+            Dictionary<string, string> result = healthCheckStatus.GetStatus("health");
 
-            Assert.Equal(status,result);
+            result.Should().Equal(status);
         }
 
         [Fact]
-        private void ShouldUpdateHealthCheckStatusWhenStatusAlreadyExists() {
-            Dictionary<string,string> status1=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Healthy" }};
-            HealthCheckStatus healthCheckStatus=new HealthCheckStatus();
-            healthCheckStatus.AddStatus("health",status1);
-            Dictionary<string,string> status2=new Dictionary<string,string>{{ "Service1", "Healthy" }, { "Service2", "Healthy" }};
-            healthCheckStatus.AddStatus("health",status2);
+        private void ShouldUpdateHealthCheckStatusWhenStatusAlreadyExists()
+        {
+            Dictionary<string, string> status1 = new Dictionary<string, string> { { "Service1", "Unhealthy" }, { "Service2", "Healthy" } };
+            HealthCheckStatus healthCheckStatus = new HealthCheckStatus();
+            healthCheckStatus.AddStatus("health", status1);
+            Dictionary<string, string> status2 = new Dictionary<string, string> { { "Service1", "Healthy" }, { "Service2", "Healthy" } };
+            healthCheckStatus.AddStatus("health", status2);
 
-            Dictionary<string,string> result = healthCheckStatus.GetStatus("health");
+            Dictionary<string, string> result = healthCheckStatus.GetStatus("health");
 
-            Assert.Equal(status2,result);
+            result.Should().Equal(status2);
         }
-        
+
         [Fact]
-        private void ShouldReturnNullWhenHealthCheckStatusIsEmpty() {
-            HealthCheckStatus healthCheckStatus=new HealthCheckStatus();
+        private void ShouldReturnNullWhenHealthCheckStatusIsEmpty()
+        {
+            HealthCheckStatus healthCheckStatus = new HealthCheckStatus();
 
-            Dictionary<string,string> result = healthCheckStatus.GetStatus("health");
+            Dictionary<string, string> result = healthCheckStatus.GetStatus("health");
 
-            Assert.Equal(null,result);
+            result.Should().BeNull();
         }
     }
 }

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckStatusTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckStatusTest.cs
@@ -13,7 +13,6 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs
     using Moq;
     using Xunit;
     using Microsoft.AspNetCore.Hosting;
-    using FluentAssertions;
 
     [Collection("Health Check Status Tests")]
     public class HealthCheckStatusTest

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckStatusTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckStatusTest.cs
@@ -1,0 +1,52 @@
+namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+    using FluentAssertions;
+    using In.ProjectEKA.HipService;
+    using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+    using Moq.Protected;
+    using Moq;
+    using Xunit;
+    using Microsoft.AspNetCore.Hosting;
+
+    [Collection ("Health Check Status Tests")]
+    public class HealthCheckStatusTest {
+       
+        [Fact]
+        private void ShouldAddHealthCheckStatusWhenAddStatusIsInvoked() {
+            Dictionary<string,string> status=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Healthy" }};
+            HealthCheckStatus healthCheckStatus=new HealthCheckStatus();
+            healthCheckStatus.AddStatus("health",status);
+
+            Dictionary<string,string> result = healthCheckStatus.GetStatus("health");
+
+            Assert.Equal(status,result);
+        }
+
+        [Fact]
+        private void ShouldUpdateHealthCheckStatusWhenStatusAlreadyExists() {
+            Dictionary<string,string> status1=new Dictionary<string,string>{{ "Service1", "Unhealthy" }, { "Service2", "Healthy" }};
+            HealthCheckStatus healthCheckStatus=new HealthCheckStatus();
+            healthCheckStatus.AddStatus("health",status1);
+            Dictionary<string,string> status2=new Dictionary<string,string>{{ "Service1", "Healthy" }, { "Service2", "Healthy" }};
+            healthCheckStatus.AddStatus("health",status2);
+
+            Dictionary<string,string> result = healthCheckStatus.GetStatus("health");
+
+            Assert.Equal(status2,result);
+        }
+        
+        [Fact]
+        private void ShouldReturnNullWhenHealthCheckStatusIsEmpty() {
+            HealthCheckStatus healthCheckStatus=new HealthCheckStatus();
+
+            Dictionary<string,string> result = healthCheckStatus.GetStatus("health");
+
+            Assert.Equal(null,result);
+        }
+    }
+}

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckerTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckerTest.cs
@@ -1,0 +1,67 @@
+namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+    using FluentAssertions;
+    using In.ProjectEKA.HipService;
+    using In.ProjectEKA.HipService.OpenMrs;
+    using Moq.Protected;
+    using Moq;
+    using Xunit;
+    using Microsoft.AspNetCore.Hosting;
+    using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+
+    [Collection ("Health Check Client Tests")]
+    public class HealthCheckerTest {
+        private Mock<IHealthCheckStatus> healthCheckStatus;
+        private Mock<IHealthCheckClient> healthCheckClient;
+        private HealthChecker healthChecker;
+
+        [Fact]
+        private void ShouldNeverUpdateHealthCheckStatus() {
+            Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "5000");
+
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (new Dictionary<string, string> (){{"service","Unhealthy"}}));
+            healthCheckStatus = new Mock<IHealthCheckStatus>();
+            healthChecker = new HealthChecker(healthCheckClient.Object,healthCheckStatus.Object);
+            
+            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(),It.IsAny<Dictionary<string,string>>()),Times.Never);
+        }
+        
+        [Fact]
+        private void ShouldUpdateHealthCheckStatusOnce() {
+            Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "5000");
+
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (new Dictionary<string, string> (){{"service","Unhealthy"}}));
+            healthCheckStatus = new Mock<IHealthCheckStatus>();
+            healthChecker = new HealthChecker(healthCheckClient.Object,healthCheckStatus.Object);
+            
+            var healthCheck = healthChecker.UpdateHealthStatus();
+
+            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(),It.IsAny<Dictionary<string,string>>()),Times.Exactly(1));
+        }
+
+        [Fact]
+        private void ShouldUpdateHealthCheckStatusMoreThanOnce() {
+            Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "10");
+
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (new Dictionary<string, string> (){{"service","Unhealthy"}}));
+            healthCheckStatus = new Mock<IHealthCheckStatus>();
+            healthChecker = new HealthChecker(healthCheckClient.Object,healthCheckStatus.Object);
+
+            Thread.Sleep(25);
+
+            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(),It.IsAny<Dictionary<string,string>>()),Times.AtLeast(2));
+        }
+
+    }
+}

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckerTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/HealthCheckerTest.cs
@@ -1,4 +1,5 @@
-namespace In.ProjectEKA.HipServiceTest.OpenMrs {
+namespace In.ProjectEKA.HipServiceTest.OpenMrs
+{
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Net;
@@ -6,61 +7,65 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs {
     using System.Threading;
     using System;
     using FluentAssertions;
-    using In.ProjectEKA.HipService;
+    using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
     using In.ProjectEKA.HipService.OpenMrs;
+    using In.ProjectEKA.HipService;
+    using Microsoft.AspNetCore.Hosting;
     using Moq.Protected;
     using Moq;
     using Xunit;
-    using Microsoft.AspNetCore.Hosting;
-    using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
-    [Collection ("Health Check Client Tests")]
-    public class HealthCheckerTest {
+    [Collection("Health Check Client Tests")]
+    public class HealthCheckerTest
+    {
         private Mock<IHealthCheckStatus> healthCheckStatus;
         private Mock<IHealthCheckClient> healthCheckClient;
         private HealthChecker healthChecker;
 
         [Fact]
-        private void ShouldNeverUpdateHealthCheckStatus() {
+        private void ShouldNeverUpdateHealthCheckStatus()
+        {
             Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "5000");
 
-            healthCheckClient = new Mock<IHealthCheckClient> ();
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (new Dictionary<string, string> (){{"service","Unhealthy"}}));
+            healthCheckClient = new Mock<IHealthCheckClient>();
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(new Dictionary<string, string>() { { "service", "Unhealthy" } }));
             healthCheckStatus = new Mock<IHealthCheckStatus>();
-            healthChecker = new HealthChecker(healthCheckClient.Object,healthCheckStatus.Object);
-            
-            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(),It.IsAny<Dictionary<string,string>>()),Times.Never);
+            healthChecker = new HealthChecker(healthCheckClient.Object, healthCheckStatus.Object);
+
+            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
         }
-        
+
         [Fact]
-        private void ShouldUpdateHealthCheckStatusOnce() {
+        private void ShouldUpdateHealthCheckStatusOnce()
+        {
             Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "5000");
 
-            healthCheckClient = new Mock<IHealthCheckClient> ();
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (new Dictionary<string, string> (){{"service","Unhealthy"}}));
+            healthCheckClient = new Mock<IHealthCheckClient>();
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(new Dictionary<string, string>() { { "service", "Unhealthy" } }));
             healthCheckStatus = new Mock<IHealthCheckStatus>();
-            healthChecker = new HealthChecker(healthCheckClient.Object,healthCheckStatus.Object);
-            
+            healthChecker = new HealthChecker(healthCheckClient.Object, healthCheckStatus.Object);
+
             var healthCheck = healthChecker.UpdateHealthStatus();
 
-            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(),It.IsAny<Dictionary<string,string>>()),Times.Exactly(1));
+            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Exactly(1));
         }
 
         [Fact]
-        private void ShouldUpdateHealthCheckStatusMoreThanOnce() {
+        private void ShouldUpdateHealthCheckStatusMoreThanOnce()
+        {
             Environment.SetEnvironmentVariable("HEALTH_CHECK_DURATION", "10");
 
-            healthCheckClient = new Mock<IHealthCheckClient> ();
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (new Dictionary<string, string> (){{"service","Unhealthy"}}));
+            healthCheckClient = new Mock<IHealthCheckClient>();
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(new Dictionary<string, string>() { { "service", "Unhealthy" } }));
             healthCheckStatus = new Mock<IHealthCheckStatus>();
-            healthChecker = new HealthChecker(healthCheckClient.Object,healthCheckStatus.Object);
+            healthChecker = new HealthChecker(healthCheckClient.Object, healthCheckStatus.Object);
 
             Thread.Sleep(25);
 
-            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(),It.IsAny<Dictionary<string,string>>()),Times.AtLeast(2));
+            healthCheckStatus.Verify(x => x.AddStatus(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.AtLeast(2));
         }
 
     }

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/OpenMrsHealthCheckClientTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/OpenMrsHealthCheckClientTest.cs
@@ -1,4 +1,5 @@
-namespace In.ProjectEKA.HipServiceTest.OpenMrs.HealthCheck {
+namespace In.ProjectEKA.HipServiceTest.OpenMrs.HealthCheck
+{
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Net;
@@ -12,104 +13,114 @@ namespace In.ProjectEKA.HipServiceTest.OpenMrs.HealthCheck {
     using Xunit;
     using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
 
-    [Collection ("Health Check Client Tests")]
-    public class OpenMrsHealthCheckClientTest {
+    [Collection("Health Check Client Tests")]
+    public class OpenMrsHealthCheckClientTest
+    {
         private Mock<IHealthCheckClient> healthCheckClient;
 
         [Fact]
-        private async void ShouldReturnDictionaryWhenCheckingForHealth () {
-            healthCheckClient = new Mock<IHealthCheckClient> ();
-            healthCheckClient.Setup (x => x.CheckHealth ())
-                .Returns (Task.FromResult (new Dictionary<string, string> ()));
+        private async void ShouldReturnDictionaryWhenCheckingForHealth()
+        {
+            healthCheckClient = new Mock<IHealthCheckClient>();
+            healthCheckClient.Setup(x => x.CheckHealth())
+                .Returns(Task.FromResult(new Dictionary<string, string>()));
 
-            var result = await healthCheckClient.Object.CheckHealth ();
+            var result = await healthCheckClient.Object.CheckHealth();
 
-            Assert.True (result.GetType ().Equals (new Dictionary<string, string> ().GetType ()));
+            result.GetType().Should().Be(new Dictionary<string, string>().GetType());
         }
 
         [Fact]
-        private async void ShouldReturnServiceAsHealthyWhenServiceHasStatus200 () {
-            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
-            var httpClient = new HttpClient (handlerMock.Object);
-            var openmrsConfiguration = new OpenMrsConfiguration {
+        private async void ShouldReturnServiceAsHealthyWhenServiceHasStatus200()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var httpClient = new HttpClient(handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration
+            {
                 Url = "https://someurl/openmrs/",
                 Username = "someusername",
                 Password = "somepassword"
             };
-            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            var openmrsClient = new OpenMrsClient(httpClient, openmrsConfiguration);
             handlerMock
-                .Protected ()
-                .Setup<Task<HttpResponseMessage>> (
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage> (),
-                    ItExpr.IsAny<CancellationToken> ()
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
                 )
-                .ReturnsAsync (new HttpResponseMessage {
+                .ReturnsAsync(new HttpResponseMessage
+                {
                     StatusCode = HttpStatusCode.OK
                 })
-                .Verifiable ();
-            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+                .Verifiable();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient(new Dictionary<string, string> { { "Service", "path/to/resource" }
             }, openmrsClient);
 
-            var result = await openMrsHealthCheckClient.CheckHealth ();
+            var result = await openMrsHealthCheckClient.CheckHealth();
 
-            Assert.True (result["Service"].Equals ("Healthy"));
+            result["Service"].Should().Be("Healthy");
         }
 
         [Fact]
-        private async void ShouldReturnServiceAsUnhealthyWhenServiceHasStatus500 () {
-            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
-            var httpClient = new HttpClient (handlerMock.Object);
-            var openmrsConfiguration = new OpenMrsConfiguration {
+        private async void ShouldReturnServiceAsUnhealthyWhenServiceHasStatus500()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var httpClient = new HttpClient(handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration
+            {
                 Url = "https://someurl/openmrs/",
                 Username = "someusername",
                 Password = "somepassword"
             };
-            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            var openmrsClient = new OpenMrsClient(httpClient, openmrsConfiguration);
             handlerMock
-                .Protected ()
-                .Setup<Task<HttpResponseMessage>> (
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage> (),
-                    ItExpr.IsAny<CancellationToken> ()
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
                 )
-                .ReturnsAsync (new HttpResponseMessage {
+                .ReturnsAsync(new HttpResponseMessage
+                {
                     StatusCode = HttpStatusCode.BadRequest
                 })
-                .Verifiable ();
-            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+                .Verifiable();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient(new Dictionary<string, string> { { "Service", "path/to/resource" }
             }, openmrsClient);
 
-            var result = await openMrsHealthCheckClient.CheckHealth ();
+            var result = await openMrsHealthCheckClient.CheckHealth();
 
-            Assert.True (result["Service"].Equals ("Unhealthy"));
+            result["Service"].Should().Be("Unhealthy");
         }
 
         [Fact]
-        private async void ShouldReturnServiceAsUnhealthyWhenRequestThrowsException () {
-            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
-            var httpClient = new HttpClient (handlerMock.Object);
-            var openmrsConfiguration = new OpenMrsConfiguration {
+        private async void ShouldReturnServiceAsUnhealthyWhenRequestThrowsException()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var httpClient = new HttpClient(handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration
+            {
                 Url = "https://someurl/openmrs/",
                 Username = "someusername",
                 Password = "somepassword"
             };
-            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            var openmrsClient = new OpenMrsClient(httpClient, openmrsConfiguration);
             handlerMock
-                .Protected ()
-                .Setup<Task<HttpResponseMessage>> (
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage> (),
-                    ItExpr.IsAny<CancellationToken> ()
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
                 )
-                .ThrowsAsync (new Exception ("Throw some exception"))
-                .Verifiable ();
-            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+                .ThrowsAsync(new Exception("Throw some exception"))
+                .Verifiable();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient(new Dictionary<string, string> { { "Service", "path/to/resource" }
             }, openmrsClient);
 
-            var result = await openMrsHealthCheckClient.CheckHealth ();
+            var result = await openMrsHealthCheckClient.CheckHealth();
 
-            Assert.True (result["Service"].Equals ("Unhealthy"));
+            result["Service"].Should().Be("Unhealthy");
         }
     }
 }

--- a/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/OpenMrsHealthCheckClientTest.cs
+++ b/test/In.ProjectEKA.HipServiceTest/OpenMrs/HealthCheck/OpenMrsHealthCheckClientTest.cs
@@ -1,0 +1,115 @@
+namespace In.ProjectEKA.HipServiceTest.OpenMrs.HealthCheck {
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System;
+    using FluentAssertions;
+    using In.ProjectEKA.HipService.OpenMrs;
+    using Moq.Protected;
+    using Moq;
+    using Xunit;
+    using In.ProjectEKA.HipService.OpenMrs.HealthCheck;
+
+    [Collection ("Health Check Client Tests")]
+    public class OpenMrsHealthCheckClientTest {
+        private Mock<IHealthCheckClient> healthCheckClient;
+
+        [Fact]
+        private async void ShouldReturnDictionaryWhenCheckingForHealth () {
+            healthCheckClient = new Mock<IHealthCheckClient> ();
+            healthCheckClient.Setup (x => x.CheckHealth ())
+                .Returns (Task.FromResult (new Dictionary<string, string> ()));
+
+            var result = await healthCheckClient.Object.CheckHealth ();
+
+            Assert.True (result.GetType ().Equals (new Dictionary<string, string> ().GetType ()));
+        }
+
+        [Fact]
+        private async void ShouldReturnServiceAsHealthyWhenServiceHasStatus200 () {
+            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
+            var httpClient = new HttpClient (handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration {
+                Url = "https://someurl/openmrs/",
+                Username = "someusername",
+                Password = "somepassword"
+            };
+            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            handlerMock
+                .Protected ()
+                .Setup<Task<HttpResponseMessage>> (
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage> (),
+                    ItExpr.IsAny<CancellationToken> ()
+                )
+                .ReturnsAsync (new HttpResponseMessage {
+                    StatusCode = HttpStatusCode.OK
+                })
+                .Verifiable ();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+            }, openmrsClient);
+
+            var result = await openMrsHealthCheckClient.CheckHealth ();
+
+            Assert.True (result["Service"].Equals ("Healthy"));
+        }
+
+        [Fact]
+        private async void ShouldReturnServiceAsUnhealthyWhenServiceHasStatus500 () {
+            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
+            var httpClient = new HttpClient (handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration {
+                Url = "https://someurl/openmrs/",
+                Username = "someusername",
+                Password = "somepassword"
+            };
+            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            handlerMock
+                .Protected ()
+                .Setup<Task<HttpResponseMessage>> (
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage> (),
+                    ItExpr.IsAny<CancellationToken> ()
+                )
+                .ReturnsAsync (new HttpResponseMessage {
+                    StatusCode = HttpStatusCode.BadRequest
+                })
+                .Verifiable ();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+            }, openmrsClient);
+
+            var result = await openMrsHealthCheckClient.CheckHealth ();
+
+            Assert.True (result["Service"].Equals ("Unhealthy"));
+        }
+
+        [Fact]
+        private async void ShouldReturnServiceAsUnhealthyWhenRequestThrowsException () {
+            var handlerMock = new Mock<HttpMessageHandler> (MockBehavior.Strict);
+            var httpClient = new HttpClient (handlerMock.Object);
+            var openmrsConfiguration = new OpenMrsConfiguration {
+                Url = "https://someurl/openmrs/",
+                Username = "someusername",
+                Password = "somepassword"
+            };
+            var openmrsClient = new OpenMrsClient (httpClient, openmrsConfiguration);
+            handlerMock
+                .Protected ()
+                .Setup<Task<HttpResponseMessage>> (
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage> (),
+                    ItExpr.IsAny<CancellationToken> ()
+                )
+                .ThrowsAsync (new Exception ("Throw some exception"))
+                .Verifiable ();
+            OpenMrsHealthCheckClient openMrsHealthCheckClient = new OpenMrsHealthCheckClient (new Dictionary<string, string> { { "Service", "path/to/resource" }
+            }, openmrsClient);
+
+            var result = await openMrsHealthCheckClient.CheckHealth ();
+
+            Assert.True (result["Service"].Equals ("Unhealthy"));
+        }
+    }
+}


### PR DESCRIPTION
1. Cases Covered:
i. When all the services are healthy -
a) Ping “/health” endpoint - would give a 200 status with “Healthy” as Response
b) All other endpoints would work the same way they did before without any errors
ii. When even one service is unhealthy -
a) Ping “/health” endpoint - would give a 500 status with the response: the services and their health status in JSON. If a service is unhealthy the message would be “Unhealthy” else “Healthy”
b) All other endpoints - same response as above

2. Health check runs every 5 seconds in background, the duration is stored as Environmental variable.