### PR TITLE
HIP# 178 - Not log the whole data response 

### DIFF
--- a/src/In.ProjectEKA.HipService/DataFlow/CollectHipService.cs
+++ b/src/In.ProjectEKA.HipService/DataFlow/CollectHipService.cs
@@ -31,7 +31,6 @@ namespace In.ProjectEKA.HipService.DataFlow
             {
                 foreach (var result in patientData.GetOrDefault(careContextReference))
                 {
-                    Log.Information($"Returning file: {result}");
                     var bundle = new FhirJsonParser().Parse<Bundle>(result);
                     bundles.Add(new CareBundle(careContextReference, bundle));
                 }


### PR DESCRIPTION
This is  to avoid crowding on docker logs